### PR TITLE
Extend api origin setting

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -340,11 +340,10 @@ exports.launchServer = () => {
         }
       }
     });
-    const isUrlReg = new RegExp('^https?://');
-    if (ObjHasProp(actionConfig, 'api')
-      && ObjHasProp(config, 'api_base_url')
-      && !actionConfig.api.match(isUrlReg)) {
-      actionConfig.api = config.api_base_url + actionConfig.api;
+
+    // APIのリクエストURLが完全でないときは各種設定からOriginを読み取り付与する
+    if (ObjHasProp(actionConfig, 'api') && !actionConfig.api.match(/^https?:\/\//)) {
+      actionConfig.api = (process.env.LAUNCHPACK_API_ORIGIN || config.launchpack_api_origin || config.api_base_url) + actionConfig.api;
     }
 
     // アクションに対応するステータスコードが設定されているときは取得する


### PR DESCRIPTION
### APIへのリクエストURLの設定処理を拡張
- APIサーバのOriginを環境変数で指定できるように更新
- APIサーバのOriginを設定する明示的な項目`launchpack_api_origin`を追加
- 後方互換性のため、旧設定項目`api_base_url`も維持
