### PR TITLE
Fix the `set-cookie` header transfer processing when redirection

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -421,14 +421,20 @@ exports.launchServer = () => {
 
                 res.setHeader('Location', redirectUrl);
 
-                const cookies = [];
-                if ('flash' in renderObj) {
-                  cookies.push(cookie.serialize('lp-flash', JSON.stringify(renderObj.flash), { path: '/' }));
-                }
+                let setCookies = [];
                 if ('set-cookie' in res.getHeaders()) {
-                  cookies.push(res.getHeaders()['set-cookie']);
+                  const responseSetCookie = res.getHeaders()['set-cookie'];
+                  if (Array.isArray(responseSetCookie)) {
+                    setCookies = responseSetCookie;
+                  } else if(typeof responseSetCookie === 'string') {
+                    setCookies.push(responseSetCookie);
+                  }
                 }
-                res.setHeader('set-cookie', cookies);
+                if ('flash' in renderObj) {
+                  setCookies.push(cookie.serialize('lp-flash', JSON.stringify(renderObj.flash), { path: '/' }));
+                }
+
+                res.setHeader('set-cookie', setCookies);
 
                 return Promise.resolve('');
               }


### PR DESCRIPTION
### リダイレクト処理時の`set-cookie`ヘッダーの転送処理を修正
- `set-cookie`ヘッダーが複数ある時に正しく転送されていなかったのを修正